### PR TITLE
Add Azure support for chat endpoint

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -7,8 +7,9 @@ module OpenAI
       OpenAI.configuration.request_timeout = request_timeout if request_timeout
     end
 
-    def chat(parameters: {})
-      OpenAI::Client.json_post(path: "/chat/completions", parameters: parameters)
+    def chat(deployment_id: nil, parameters: {})
+      OpenAI::Client.json_post(deployment_id: deployment_id, path: "/chat/completions",
+                               parameters: parameters)
     end
 
     def completions(deployment_id: nil, parameters: {})

--- a/spec/fixtures/cassettes/gpt-3_5-turbo_chat.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo_chat.yml
@@ -53,4 +53,59 @@ http_interactions:
 
         '
   recorded_at: Wed, 01 Mar 2023 18:24:32 GMT
+- request:
+    method: post
+    uri: "<OPENAI_URI_BASE>openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-03-15-preview"
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":"Hello!"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Api-Key:
+      - "<OPENAI_ACCESS_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, must-revalidate
+      Content-Length:
+      - '320'
+      Content-Type:
+      - application/json
+      Access-Control-Allow-Origin:
+      - "*"
+      Apim-Request-Id:
+      - ccae9e53-9848-4584-a2a1-d5aa9f42866a
+      Openai-Model:
+      - gpt-35-turbo
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Openai-Processing-Ms:
+      - '872.1621'
+      X-Ms-Region:
+      - East US
+      X-Accel-Buffering:
+      - 'no'
+      X-Request-Id:
+      - 4f5d80ba-be8e-412a-bd87-897cffece773
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 25 Apr 2023 13:04:46 GMT
+    body:
+      encoding: UTF-8
+      string: '{"id":"chatcmpl-79CdaV6cRIZIgck8QC3posii5MAyJ","object":"chat.completion","created":1682427886,"model":"gpt-35-turbo","usage":{"prompt_tokens":10,"completion_tokens":10,"total_tokens":20},"choices":[{"message":{"role":"assistant","content":"Hello
+        there. How may I assist you today?"},"finish_reason":"stop","index":0}]}
+
+        '
+  recorded_at: Tue, 25 Apr 2023 13:04:47 GMT
 recorded_with: VCR 6.1.0

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -1,38 +1,68 @@
 RSpec.describe OpenAI::Client do
-  describe "#chat" do
-    context "with messages", :vcr do
-      let(:messages) { [{ role: "user", content: "Hello!" }] }
+  describe "#chat", :vcr do
+    let(:messages) { [{ role: "user", content: "Hello!" }] }
+    let(:content) { JSON.parse(response.body).dig("choices", 0, "message", "content") }
+    let(:cassette) { "#{model} chat".downcase }
+    let(:response) do
+      OpenAI::Client.new.chat(
+        parameters: {
+          model: model,
+          messages: messages
+        }
+      )
+    end
+
+    context "with model: gpt-3.5-turbo-0301" do
+      let(:model) { "gpt-3.5-turbo-0301" }
+
+      it "succeeds" do
+        VCR.use_cassette(cassette) do
+          expect(content.split.empty?).to eq(false)
+        end
+      end
+    end
+
+    shared_examples_for "with model: gpt-3.5-turbo" do
+      let(:model) { "gpt-3.5-turbo" }
+
+      it "succeeds" do
+        VCR.use_cassette(cassette) do
+          expect(content.split.empty?).to eq(false)
+        end
+      end
+    end
+
+    it_behaves_like "with model: gpt-3.5-turbo"
+
+    context "with Azure" do
+      before do
+        OpenAI.configure do |config|
+          config.api_type = :azure
+          config.api_version = "2023-03-15-preview"
+          config.uri_base = ENV.fetch("AZURE_URI_BASE")
+          config.access_token = ENV.fetch("AZURE_ACCESS_TOKEN")
+        end
+      end
+
+      after do
+        OpenAI.configure do |config|
+          config.api_type = nil
+          config.api_version = OpenAI::Configuration::DEFAULT_API_VERSION
+          config.uri_base = OpenAI::Configuration::DEFAULT_URI_BASE
+          config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
+        end
+      end
 
       let(:response) do
         OpenAI::Client.new.chat(
+          deployment_id: "gpt-35-turbo",
           parameters: {
-            model: model,
             messages: messages
           }
         )
       end
-      let(:content) { JSON.parse(response.body).dig("choices", 0, "message", "content") }
-      let(:cassette) { "#{model} chat".downcase }
 
-      context "with model: gpt-3.5-turbo" do
-        let(:model) { "gpt-3.5-turbo" }
-
-        it "succeeds" do
-          VCR.use_cassette(cassette) do
-            expect(content.split.empty?).to eq(false)
-          end
-        end
-      end
-
-      context "with model: gpt-3.5-turbo-0301" do
-        let(:model) { "gpt-3.5-turbo-0301" }
-
-        it "succeeds" do
-          VCR.use_cassette(cassette) do
-            expect(content.split.empty?).to eq(false)
-          end
-        end
-      end
+      it_behaves_like "with model: gpt-3.5-turbo"
     end
   end
 end


### PR DESCRIPTION
This is meant to merge into `feature/microsoft-azure` as a way to support the "chat" endpoint. The "chat" endpoint includes support for ChatGPT and GPT-4 models. Some documentation is available [here](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#chat-completions). 

To accomplish this, we added support for Azure's `deployment_id` to the "chat" endpoint and updated the existing spec to reflect these changes.