### PR TITLE
gh actions: Add publish job

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,15 @@
+name: ruby
+on: [push]
+jobs:
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          mkdir ~/.gem
+          echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
+          chmod 600 ~/.gem/credentials
+      - run: gem build ruby-openai.gemspec
+      - run: gem push --key github --host https://rubygems.pkg.github.com/feedbackfruits ruby-openai-*.gem


### PR DESCRIPTION
This PR adds a `publish` job to pubish the gem to (our) GH packages whenever a tag is cut.