### PR TITLE
Support Microsoft Azure

### DIFF
--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -15,7 +15,7 @@ module OpenAI
 
   class Configuration
     attr_writer :access_token
-    attr_accessor :api_version, :organization_id, :uri_base, :request_timeout
+    attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout
 
     DEFAULT_API_VERSION = "v1".freeze
     DEFAULT_URI_BASE = "https://api.openai.com/".freeze
@@ -23,6 +23,7 @@ module OpenAI
 
     def initialize
       @access_token = nil
+      @api_type = nil
       @api_version = DEFAULT_API_VERSION
       @organization_id = nil
       @uri_base = DEFAULT_URI_BASE

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -68,14 +68,27 @@ module OpenAI
     end
 
     def uri(path:)
-      OpenAI.configuration.uri_base + OpenAI.configuration.api_version + path
+      if OpenAI.configuration.api_type == :azure
+        OpenAI.configuration.uri_base + path + "?api-version=#{OpenAI.configuration.api_version}"
+      else
+        OpenAI.configuration.uri_base + OpenAI.configuration.api_version + path
+      end
     end
 
     def headers
+      return azure_headers if OpenAI.configuration.api_type == :azure
+
       {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{OpenAI.configuration.access_token}",
         "OpenAI-Organization" => OpenAI.configuration.organization_id
+      }
+    end
+
+    def azure_headers
+      {
+        "Content-Type" => "application/json",
+        "api-key" => OpenAI.configuration.access_token
       }
     end
 

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -69,9 +69,9 @@ module OpenAI
 
     def uri(path:)
       if OpenAI.configuration.api_type == :azure
-        OpenAI.configuration.uri_base + path + "?api-version=#{OpenAI.configuration.api_version}"
+        URI.join(OpenAI.configuration.uri_base,  path).to_s + "?api-version=#{OpenAI.configuration.api_version}"
       else
-        OpenAI.configuration.uri_base + OpenAI.configuration.api_version + path
+        URI.join(OpenAI.configuration.uri_base,  OpenAI.configuration.api_version).to_s + path
       end
     end
 

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -184,4 +184,38 @@ RSpec.describe OpenAI::HTTP do
       it { expect(parsed).to eq([{ "prompt" => ":)" }, { "prompt" => ":(" }]) }
     end
   end
+
+  describe ".uri" do
+    let(:path) { "/chat" }
+    let(:uri) { OpenAI::Client.send(:uri, path: path) }
+
+    it { expect(uri).to eq("https://api.openai.com/v1/chat") }
+
+    describe "with Azure" do
+      before do
+        OpenAI.configuration.api_type = :azure
+      end
+
+      let(:path) { "/chat" }
+      let(:uri) { OpenAI::Client.send(:uri, path: path) }
+
+      it { expect(uri).to eq("https://api.openai.com/chat?api-version=v1") }
+    end
+  end
+
+  describe ".headers" do
+    let(:headers) { OpenAI::Client.send(:headers) }
+
+    it { expect(headers).to eq({ "Authorization" => "Bearer #{OpenAI.configuration.access_token}", "Content-Type" => "application/json", "OpenAI-Organization" => nil }) }
+
+    describe "with Azure" do
+      before do
+        OpenAI.configuration.api_type = :azure
+      end
+
+      let(:headers) { OpenAI::Client.send(:headers) }
+
+      it { expect(headers).to eq({ "Content-Type" => "application/json", "api-key" => OpenAI.configuration.access_token }) }
+    end
+  end
 end


### PR DESCRIPTION
This PR adds Azure support with minimal changes to the existing logic. Specifically, it only modifies the `uri` and `headers` to allow requests to go to the correct endpoint and have the `api-version` query param, and to make sure the headers contain an `api-key` instead of an `Authorization` header.

In order to use this with Azure, you need something like this in your `config/initializers/openai.rb`:
```ruby
require 'openai'

OpenAI.configure do |config|
  config.access_token = Rails.application.config.app[:azure_openai_api_key]
  config.uri_base = "#{Rails.application.config.app[:azure_openai_url]}/openai/deployments/gpt-35-turbo"
  config.api_type = :azure
  config.api_version = '2023-03-15-preview'
end
```